### PR TITLE
Fix restore SQL ERROR 1075 (42000)

### DIFF
--- a/nideshop.sql
+++ b/nideshop.sql
@@ -4699,7 +4699,7 @@ CREATE TABLE `nideshop_keywords` (
   `scheme _url` varchar(255) NOT NULL DEFAULT '' COMMENT '关键词的跳转链接',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `type` int(11) unsigned NOT NULL DEFAULT '0',
-  PRIMARY KEY (`keyword`,`id`)
+  PRIMARY KEY (`id`,`keyword`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='热闹关键词表';
 
 -- ----------------------------


### PR DESCRIPTION
由于 engine 从 MyISAM 修改为 InnoDB，在创建表 nideshop_keywords 时，会抛错 ERROR 1075 (42000): Incorrect table definition; there can be only one auto column and it must be defined as a key （在 MyISAM 下不会有问题），此时将语句中的 PRIMARY KEY (keyword,id) 修改为 PRIMARY KEY (id, keyword) 即可。